### PR TITLE
[ENG-19809] Comment out multusAnnotation generation

### DIFF
--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -109,9 +109,9 @@ func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8
 		annotations[downwardapi.NetworkInfoAnnot] = deviceInfoAnnotation
 	}
 
-	if updatedMultusAnnotation, shouldUpdate := g.generateMultusAnnotation(vmi, pod); shouldUpdate {
-		annotations[networkv1.NetworkAttachmentAnnot] = updatedMultusAnnotation
-	}
+	//if updatedMultusAnnotation, shouldUpdate := g.generateMultusAnnotation(vmi, pod); shouldUpdate {
+	//	annotations[networkv1.NetworkAttachmentAnnot] = updatedMultusAnnotation
+	//}
 
 	return annotations
 }


### PR DESCRIPTION
This is required in order to disable continuous reconciliation of the `k8s.cni.cncf.io/networks:` annotation of the pods managed by KubeVirt, because we fill this annotation using `ib-sriov-cni` instead 