### PR TITLE
fix(k8s/types): add ObservedGeneration field to PodCondition struct

### DIFF
--- a/vendor/k8s.io/api/core/v1/types.go
+++ b/vendor/k8s.io/api/core/v1/types.go
@@ -3251,6 +3251,12 @@ type PodCondition struct {
 	// Type is the type of the condition.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
 	Type PodConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=PodConditionType"`
+	// copied from https://github.com/kubernetes/api/blob/133a39c86037e673501accd93a01467e8ab69c3a/core/v1/types.go#L3568-L3572
+	// If set, this represents the .metadata.generation that the pod condition was set based upon.
+	// This is an alpha field. Enable PodObservedGenerationTracking to be able to use this field.
+	// +featureGate=PodObservedGenerationTracking
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,7,opt,name=observedGeneration"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions


### PR DESCRIPTION
This adds the `ObservedGeneration` field, introduced in Kubernetes `1.34`, to the `PodCondition` struct.

The absence of the field was causing issues in a `k3s` `1.34` substrate, where `virt-controller` was unable to update a pod's `status.conditions` in `syncPausedConditionToPod()` because the patch request contained an initial `test` operation, with the existing conditions missing the `ObservedGeneration` field, causing the API server to fail the patch request with "the server rejected our request due to an error in our request".

Related Slack thread: https://togetherai.slack.com/archives/C08HVAQ234J/p1767210936339809?thread_ts=1767148416.208299&cid=C08HVAQ234J .
