### PR TITLE
fix(virt-controller): sort interfaces before deep equal comparison

### DIFF
--- a/build-push.sh
+++ b/build-push.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# this script depends on being logged in to the "together.ai - prod" public
+# ECR registry; to login run
+# aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+export DOCKER_PREFIX='public.ecr.aws/k6t4m3l7/kubevirt'
+DOCKER_TAG="$(git describe --tags)"
+export DOCKER_TAG
+PUSH_TARGETS="${PUSH_TARGETS:-"virt-controller"}"
+
+read -rp "Build tag $DOCKER_TAG for ${PUSH_TARGETS// /, } image(s)? [y/N] " response
+
+if [ "$response" = 'y' ] || [ "$response" = 'Y' ]; then
+  make bazel-push-images PUSH_TARGETS="$PUSH_TARGETS"
+fi

--- a/build-push.sh
+++ b/build-push.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 # aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
 export DOCKER_PREFIX='public.ecr.aws/k6t4m3l7/kubevirt'
-DOCKER_TAG="$(git describe --tags)"
+DOCKER_TAG="${DOCKER_TAG:-"$(git describe --tags)"}"
 export DOCKER_TAG
-PUSH_TARGETS="${PUSH_TARGETS:-"virt-controller"}"
+PUSH_TARGETS="${PUSH_TARGETS:-virt-controller}"
 
 read -rp "Build tag $DOCKER_TAG for ${PUSH_TARGETS// /, } image(s)? [y/N] " response
 

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -803,7 +803,7 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 		}
 	}
 
-	// Sort network interfaces by name to ensure that the order does not affect the equality check.
+	// Sort network interfaces by name or interface name to ensure that the order does not affect the equality check.
 	// Prior to this an API patch flood would occur - see: https://github.com/kubevirt/kubevirt/issues/14442
 	cmpFunc := func(a, b virtv1.VirtualMachineInstanceNetworkInterface) int {
 		if a.Name == "" && b.Name == "" {

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -802,7 +803,25 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 		}
 	}
 
-	if !equality.Semantic.DeepEqual(newVMI.Status.Interfaces, oldVMI.Status.Interfaces) {
+	// Sort network interfaces by name to ensure that the order does not affect the equality check.
+	// Prior to this an API patch flood would occur - see: https://github.com/kubevirt/kubevirt/issues/14442
+	cmpFunc := func(a, b virtv1.VirtualMachineInstanceNetworkInterface) int {
+		if a.Name == "" && b.Name == "" {
+			return strings.Compare(a.InterfaceName, b.InterfaceName)
+		}
+		if a.Name == "" && b.Name != "" {
+			return 1
+		}
+		if a.Name != "" && b.Name == "" {
+			return -1
+		}
+		return strings.Compare(a.Name, b.Name)
+	}
+	newInterfaces := slices.Clone(newVMI.Status.Interfaces)
+	oldInterfaces := slices.Clone(oldVMI.Status.Interfaces)
+	slices.SortFunc(newInterfaces, cmpFunc)
+	slices.SortFunc(oldInterfaces, cmpFunc)
+	if !equality.Semantic.DeepEqual(newInterfaces, oldInterfaces) {
 		patchSet.AddOption(
 			patch.WithTest("/status/interfaces", oldVMI.Status.Interfaces),
 			patch.WithAdd("/status/interfaces", newVMI.Status.Interfaces),


### PR DESCRIPTION
This PR adds sorting of VMI `status.interfaces` before the `DeepEqual()` comparison between old and new interfaces.

This is required because `virt-handler` and `virt-controller` both update VMIs `status.interfaces`, but they calculate them in different order, so the `DeepEqual()` in `virt-controller` returns `false`, causing the VMI to be continuously updated by both components, in turn. Addressing this in `virt-controller` is enough to fix the continuous updating. 

This was (partly) fixed upstream in https://github.com/kubevirt/kubevirt/pull/14613, but the `cmpFunc` is still incomplete for our use case, where we have interfaces with `Name` not set, but instead having `InterfaceName` set.

Example interface with `Name` set:

```json
      {
        "name": "mlnx_connectx_7_dp_gpu_eth_storage_2-1",
        "infoSource": "domain, multus-status"
      }
```

Example interface with `Name` not set and `InterfaceName` set:

```json
      {
        "ipAddress": "10.174.128.2",
        "mac": "0a:5b:e1:92:0e:67",
        "ipAddresses": [
          "10.174.128.2",
          "fe80::85b:e1ff:fe92:e67"
        ],
        "interfaceName": "enp93s0",
        "infoSource": "guest-agent"
      }
```

To handle that, we first order the interfaces with `Name` set, by `Name`, and then order the ones with `Name` not set, by `InterfaceName`.