### PR TITLE
fix(network): stop clobbering a foreign-owned multus networks annotation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,6 +50,14 @@ const (
 	BurstReplicas uint = 250
 )
 
+// VirtControllerFieldManager is the field manager name recorded in an object's
+// managedFields when virt-controller patches it. It is set explicitly so other
+// code can reason about field ownership deterministically.
+//
+// NOTE: pkg/network/pod/annotations mirrors this value in a local constant
+// (virtControllerFieldManager) to avoid importing this package; keep them in sync.
+const VirtControllerFieldManager = "virt-controller"
+
 // Reasons for vmi events
 const (
 	// FailedCreatePodReason is added in an event and in a vmi controller condition
@@ -588,7 +596,7 @@ func SyncPodAnnotations(clientset kubecli.KubevirtClient, pod *k8sv1.Pod, newAnn
 	if err != nil {
 		return pod, fmt.Errorf("failed to generate patch payload: %w", err)
 	}
-	patchedPod, err := clientset.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	patchedPod, err := clientset.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: VirtControllerFieldManager})
 	if err != nil {
 		log.Log.Object(pod).Errorf("failed to sync pod annotations: %v", err)
 		return nil, err

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -20,6 +20,8 @@
 package annotations
 
 import (
+	"encoding/json"
+
 	k8scorev1 "k8s.io/api/core/v1"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -127,7 +129,52 @@ func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8
 	return annotations
 }
 
+// virtControllerFieldManager mirrors controller.VirtControllerFieldManager: the
+// field manager name virt-controller records when it patches a pod. It is
+// duplicated here (rather than imported) to avoid pulling the heavy
+// pkg/controller package into the network annotations dependency graph; the
+// value is a stable managedFields wire contract.
+const virtControllerFieldManager = "virt-controller"
+
+// multusNetworksAnnotationOwnedByAnotherManager reports whether the multus
+// networks annotation on the pod is currently owned (in managedFields) by a
+// field manager other than virt-controller. In that case an external controller
+// (e.g. ib-kubernetes, which injects InfiniBand GUIDs) manages the annotation,
+// and virt-controller must not overwrite it.
+func multusNetworksAnnotationOwnedByAnotherManager(pod *k8scorev1.Pod) bool {
+	const annotationField = "f:" + networkv1.NetworkAttachmentAnnot
+	for _, mf := range pod.ManagedFields {
+		if mf.Manager == virtControllerFieldManager || mf.FieldsV1 == nil {
+			continue
+		}
+		var fields map[string]interface{}
+		if err := json.Unmarshal(mf.FieldsV1.Raw, &fields); err != nil {
+			continue
+		}
+		metadata, ok := fields["f:metadata"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		annotations, ok := metadata["f:annotations"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, owned := annotations[annotationField]; owned {
+			return true
+		}
+	}
+	return false
+}
+
 func (g Generator) generateMultusAnnotation(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) (string, bool) {
+	const logLevel = 4
+
+	if multusNetworksAnnotationOwnedByAnotherManager(pod) {
+		log.Log.Object(pod).V(logLevel).Infof(
+			"skipping multus network annotation update: annotation is owned by another field manager")
+		return "", false
+	}
+
 	vmiSpecIfaces, vmiSpecNets, ifaceChangeRequired := ifacesAndNetsForMultusAnnotationUpdate(vmi)
 	if !ifaceChangeRequired {
 		return "", false
@@ -147,7 +194,6 @@ func (g Generator) generateMultusAnnotation(vmi *v1.VirtualMachineInstance, pod 
 
 	currentMultusAnnotation := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 
-	const logLevel = 4
 	log.Log.Object(pod).V(logLevel).Infof(
 		"current multus annotation for pod: %s; updated multus annotation for pod with: %s",
 		currentMultusAnnotation,

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -764,6 +764,83 @@ var _ = Describe("Annotations Generator", func() {
 			Expect(annotations).To(HaveKeyWithValue(networkv1.NetworkAttachmentAnnot, ""))
 		})
 	})
+
+	Context("Multus annotation field ownership", func() {
+		const (
+			sriovNetworkName = "sriov-net"
+			sriovNADName     = "default/sriov"
+
+			// enrichedMultusNetworksAnnotation stands in for the value an external
+			// controller (e.g. ib-kubernetes) writes: the base multus network list
+			// enriched with data KubeVirt never regenerates from the VMI spec.
+			enrichedMultusNetworksAnnotation = `[{"name":"sriov","namespace":"default",` +
+				`"infiniband-guid":"02:00:00:00:00:00:00:01",` +
+				`"cni-args":{"mellanox.infiniband.app":"configured"}}]`
+
+			networkStatusWithPrimaryAndSRIOVSecondaryNet = `[` +
+				`{"name":"k8s-pod-network","ips":["10.244.196.146"],"default":true,"dns":{}},` +
+				`{"name":"default/sriov","interface":"pod778c553efa0","dns":{}}` +
+				`]`
+		)
+
+		// newVMIWithUnpluggedSRIOVIface reproduces the reported scenario: a primary
+		// pod network plus a single SR-IOV interface that is not yet reflected in
+		// vmi.Status.Interfaces. In this state generateMultusAnnotation would
+		// otherwise recompute the multus annotation down to "" and clear it.
+		newVMIWithUnpluggedSRIOVIface := func() *v1.VirtualMachineInstance {
+			return libvmi.New(
+				libvmi.WithNamespace(testNamespace),
+				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkName)),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(sriovNetworkName, sriovNADName)),
+			)
+		}
+
+		managedFieldsOwningNetworksAnnotation := func(manager string) []metav1.ManagedFieldsEntry {
+			return []metav1.ManagedFieldsEntry{{
+				Manager:   manager,
+				Operation: metav1.ManagedFieldsOperationUpdate,
+				FieldsV1: &metav1.FieldsV1{
+					Raw: []byte(`{"f:metadata":{"f:annotations":{"f:k8s.v1.cni.cncf.io/networks":{}}}}`),
+				},
+			}}
+		}
+
+		It("should not update the multus annotation when another field manager owns it", func() {
+			vmi := newVMIWithUnpluggedSRIOVIface()
+
+			pod := newStubVirtLauncherPod(vmi, map[string]string{
+				networkv1.NetworkAttachmentAnnot: enrichedMultusNetworksAnnotation,
+				networkv1.NetworkStatusAnnot:     networkStatusWithPrimaryAndSRIOVSecondaryNet,
+			})
+			pod.ManagedFields = managedFieldsOwningNetworksAnnotation("ib-kubernetes")
+
+			generator := annotations.NewGenerator(stubClusterConfig{})
+			actualAnnotations := generator.GenerateFromActivePod(vmi, pod)
+
+			Expect(actualAnnotations).ToNot(HaveKey(networkv1.NetworkAttachmentAnnot))
+		})
+
+		DescribeTable("should update the multus annotation when it is not owned by another field manager",
+			func(managedFields []metav1.ManagedFieldsEntry) {
+				vmi := newVMIWithUnpluggedSRIOVIface()
+
+				pod := newStubVirtLauncherPod(vmi, map[string]string{
+					networkv1.NetworkAttachmentAnnot: enrichedMultusNetworksAnnotation,
+					networkv1.NetworkStatusAnnot:     networkStatusWithPrimaryAndSRIOVSecondaryNet,
+				})
+				pod.ManagedFields = managedFields
+
+				generator := annotations.NewGenerator(stubClusterConfig{})
+				actualAnnotations := generator.GenerateFromActivePod(vmi, pod)
+
+				Expect(actualAnnotations).To(HaveKeyWithValue(networkv1.NetworkAttachmentAnnot, ""))
+			},
+			Entry("when virt-controller owns the annotation", managedFieldsOwningNetworksAnnotation("virt-controller")),
+			Entry("when no field manager owns the annotation", nil),
+		)
+	})
 })
 
 func newMultusDefaultPodNetwork(name, networkAttachmentDefinitionName string) *v1.Network {


### PR DESCRIPTION
Part of ENG-91087

On a VM whose virt-launcher pod has SR-IOV interfaces, virt-controller's
ready-pod annotation sync recomputes the `k8s.v1.cni.cncf.io/networks`
annotation purely from the VMI spec and status. While an SR-IOV interface is
not yet reflected in `vmi.Status.Interfaces`, the recompute collapses to `""`,
wiping enrichment (e.g. InfiniBand GUIDs and `cni-args`) that an external
controller such as ib-kubernetes wrote — and the JSON-patch also transfers
managedFields ownership away from that controller.

## Changes

- add `VirtControllerFieldManager` constant and set it explicitly as the
  `FieldManager` on the `SyncPodAnnotations` patch, so field ownership is
  deterministic
- skip the multus networks annotation update in `generateMultusAnnotation` when
  the annotation is owned in managedFields by a manager other than
  virt-controller, yielding the annotation to that controller
- add tests covering foreign-owned (skipped), virt-controller-owned and unowned
  (not skipped) cases

## Behavior note

Once another manager owns the annotation, virt-controller no longer manages it
for that pod (including genuine SR-IOV hotplug); this matches the
ib-kubernetes/UFM division of responsibility.
