### PR TITLE
fix(network): make vmi.Status.Interfaces ordering deterministic in virt-handler

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -121,7 +121,7 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 		interfacesStatus = movePrimaryIfaceStatusToFront(interfacesStatus, primaryNetwork.Name)
 	}
 
-	interfacesStatus = ifacesStatusFromMultus(interfacesStatus, multusStatusNetworksByName, vmiInterfacesSpecByName)
+	interfacesStatus = ifacesStatusFromMultus(interfacesStatus, multusStatusNetworksByName, vmi.Spec.Domain.Devices.Interfaces)
 
 	interfacesStatus = restorePodIfaceNames(interfacesStatus, vmi.Status.Interfaces)
 	vmi.Status.Interfaces = interfacesStatus
@@ -194,19 +194,31 @@ func movePrimaryIfaceStatusToFront(
 func ifacesStatusFromMultus(
 	interfacesStatus []v1.VirtualMachineInstanceNetworkInterface,
 	multusStatusNetworksByName map[string]v1.VirtualMachineInstanceNetworkInterface,
-	vmIfacesSpecByName map[string]v1.Interface,
+	vmiIfacesSpec []v1.Interface,
 ) []v1.VirtualMachineInstanceNetworkInterface {
+	// Add the multus info-source to interfaces already present in the status.
+	// Iteration order is irrelevant here: only existing entries are mutated in place.
 	for multusIfaceName := range multusStatusNetworksByName {
-		ifaceStatus := netvmispec.LookupInterfaceStatusByName(interfacesStatus, multusIfaceName)
-		_, existInSpec := vmIfacesSpecByName[multusIfaceName]
-		if existInSpec && ifaceStatus == nil {
-			interfacesStatus = append(interfacesStatus, v1.VirtualMachineInstanceNetworkInterface{
-				Name:       multusIfaceName,
-				InfoSource: netvmispec.InfoSourceMultusStatus,
-			})
-		} else if ifaceStatus != nil {
+		if ifaceStatus := netvmispec.LookupInterfaceStatusByName(interfacesStatus, multusIfaceName); ifaceStatus != nil {
 			ifaceStatus.InfoSource = netvmispec.AddInfoSource(ifaceStatus.InfoSource, netvmispec.InfoSourceMultusStatus)
 		}
+	}
+
+	// Append interfaces reported only by multus (present in spec and in the multus
+	// network-status, but not yet in the status) in VMI spec order. This keeps
+	// vmi.Status.Interfaces deterministic across reconciles and aligned with the
+	// virt-controller ordering (pkg/network/controllers/vmi.go), avoiding status churn.
+	for _, iface := range vmiIfacesSpec {
+		if _, inMultus := multusStatusNetworksByName[iface.Name]; !inMultus {
+			continue
+		}
+		if netvmispec.LookupInterfaceStatusByName(interfacesStatus, iface.Name) != nil {
+			continue
+		}
+		interfacesStatus = append(interfacesStatus, v1.VirtualMachineInstanceNetworkInterface{
+			Name:       iface.Name,
+			InfoSource: netvmispec.InfoSourceMultusStatus,
+		})
 	}
 	return interfacesStatus
 }

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -104,7 +104,7 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 
 	interfacesStatus := ifacesStatusFromDomainInterfaces(domain.Spec.Devices.Interfaces)
 	interfacesStatus = append(interfacesStatus,
-		sriovIfacesStatusFromDomainHostDevices(domain.Spec.Devices.HostDevices, vmiInterfacesSpecByName)...,
+		sriovIfacesStatusFromDomainHostDevices(domain.Spec.Devices.HostDevices, vmi.Spec.Domain.Devices.Interfaces)...,
 	)
 
 	var err error
@@ -319,7 +319,13 @@ func linkStateFromDomain(linkState *api.LinkState) string {
 	return linkState.State
 }
 
-func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfacesSpecByName map[string]v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {
+func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfacesSpec []v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {
+	vmiIfacesSpecByName := netvmispec.IndexInterfaceSpecByName(vmiIfacesSpec)
+	specOrder := make(map[string]int, len(vmiIfacesSpec))
+	for i := range vmiIfacesSpec {
+		specOrder[vmiIfacesSpec[i].Name] = i
+	}
+
 	var vmiStatusIfaces []v1.VirtualMachineInstanceNetworkInterface
 
 	for _, hostDevice := range filterHostDevicesByAlias(hostDevices, deviceinfo.SRIOVAliasPrefix) {
@@ -332,6 +338,23 @@ func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfa
 		}
 		vmiStatusIfaces = append(vmiStatusIfaces, vmiStatusIface)
 	}
+
+	// The domain host-device order does not necessarily match the VMI spec order (it
+	// follows PCI-address pool / libvirt slot assignment). Order the SR-IOV interface
+	// statuses by VMI spec order so virt-handler agrees with the virt-controller's
+	// spec-ordered status (pkg/network/controllers/vmi.go) and avoids status churn.
+	// Host devices with no matching spec interface (should not happen) sort last,
+	// keeping their original relative order.
+	specIndex := func(name string) int {
+		if idx, exists := specOrder[name]; exists {
+			return idx
+		}
+		return len(vmiIfacesSpec)
+	}
+	slices.SortStableFunc(vmiStatusIfaces, func(a, b v1.VirtualMachineInstanceNetworkInterface) int {
+		return specIndex(a.Name) - specIndex(b.Name)
+	})
+
 	return vmiStatusIfaces
 }
 

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -1077,6 +1077,76 @@ var _ = Describe("netstat", func() {
 		)
 	})
 
+	It("secondary multus-only interfaces are ordered by VMI spec order (deterministic)", func() {
+		const (
+			primaryNetworkName = "primary"
+			primaryPodIPv4     = "1.1.1.1"
+			primaryMAC         = "1C:CE:C0:01:BE:E7"
+
+			// Declared in a deliberately non-alphabetical spec order so the assertion is
+			// meaningful: spec order (net-c, net-a, net-b) differs from alphabetical order.
+			secNetC = "net-c"
+			secNetA = "net-a"
+			secNetB = "net-b"
+		)
+
+		// Primary pod network, backed by the domain, so it is reported and pinned first.
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithBridgeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				primaryPodIPv4,
+			),
+		).To(Succeed())
+
+		// Three secondary multus networks, added to the VMI spec *only* (not to the domain),
+		// so they can enter the status exclusively through the append branch of
+		// ifacesStatusFromMultus.
+		for _, name := range []string{secNetC, secNetA, secNetB} {
+			setup.Vmi.Spec.Domain.Devices.Interfaces = append(setup.Vmi.Spec.Domain.Devices.Interfaces,
+				newVMISpecIfaceWithBridgeBinding(name))
+			setup.Vmi.Spec.Networks = append(setup.Vmi.Spec.Networks, newVMISpecMultusNetwork(name))
+		}
+
+		// The previous status carries the secondaries as multus-status-only entries. This
+		// populates multusStatusNetworksByName and drives them through the append branch
+		// (they are not reported by the domain / guest-agent). The stored order is
+		// scrambled on purpose to prove the output order derives from the spec, not from
+		// the previous status.
+		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: primaryNetworkName},
+			{Name: secNetB, InfoSource: netvmispec.InfoSourceMultusStatus},
+			{Name: secNetC, InfoSource: netvmispec.InfoSourceMultusStatus},
+			{Name: secNetA, InfoSource: netvmispec.InfoSourceMultusStatus},
+		}
+
+		expectedStatus := []v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       primaryNetworkName,
+				IP:         primaryPodIPv4,
+				IPs:        []string{primaryPodIPv4},
+				MAC:        primaryMAC,
+				InfoSource: netvmispec.InfoSourceDomain,
+				QueueCount: netsetup.DefaultInterfaceQueueCount,
+				LinkState:  linkStateUp,
+			},
+			{Name: secNetC, InfoSource: netvmispec.InfoSourceMultusStatus},
+			{Name: secNetA, InfoSource: netvmispec.InfoSourceMultusStatus},
+			{Name: secNetB, InfoSource: netvmispec.InfoSourceMultusStatus},
+		}
+
+		// Determinism guard: repeated reconciles must produce identical ordering. Feeding
+		// the result back as the previous status mirrors the real self-perpetuating
+		// reconcile loop. With the old map-range append this is flaky by construction;
+		// with the spec-ordered append it is stable.
+		for i := 0; i < 20; i++ {
+			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+			Expect(setup.Vmi.Status.Interfaces).To(Equal(expectedStatus),
+				fmt.Sprintf("iteration %d: secondary multus-only ifaces must follow VMI spec order", i))
+		}
+	})
+
 	It("run status and expect 1 attached iface & 1 detached iface to be reported based on multus status and guest-agent data", func() {
 		const (
 			primaryNetworkName = "primary"

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -1147,6 +1147,66 @@ var _ = Describe("netstat", func() {
 		}
 	})
 
+	It("SR-IOV interfaces are ordered by VMI spec order regardless of domain host-device order (deterministic)", func() {
+		const (
+			primaryNetworkName = "primary"
+			primaryPodIPv4     = "1.1.1.1"
+			primaryMAC         = "1C:CE:C0:01:BE:E7"
+
+			sriovNet1 = "sriov-net-1"
+			sriovNet2 = "sriov-net-2"
+			sriovNet3 = "sriov-net-3"
+		)
+
+		// Primary pod network, backed by the domain, so it is reported and pinned first.
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithBridgeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				primaryPodIPv4,
+			),
+		).To(Succeed())
+
+		// Three SR-IOV secondaries declared in spec order 1, 2, 3.
+		for _, name := range []string{sriovNet1, sriovNet2, sriovNet3} {
+			setup.Vmi.Spec.Domain.Devices.Interfaces = append(setup.Vmi.Spec.Domain.Devices.Interfaces,
+				newVMISpecIfaceWithSRIOVBinding(name))
+			setup.Vmi.Spec.Networks = append(setup.Vmi.Spec.Networks, newVMISpecMultusNetwork(name))
+		}
+
+		// The domain reports the SR-IOV host devices in a different order than the spec
+		// (2, 3, 1) — as happens in practice due to PCI-address / libvirt slot assignment.
+		for _, name := range []string{sriovNet2, sriovNet3, sriovNet1} {
+			setup.Domain.Spec.Devices.HostDevices = append(setup.Domain.Spec.Devices.HostDevices,
+				api.HostDevice{Alias: api.NewUserDefinedAlias(netsriov.SRIOVAliasPrefix + name)})
+		}
+
+		expectedStatus := []v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       primaryNetworkName,
+				IP:         primaryPodIPv4,
+				IPs:        []string{primaryPodIPv4},
+				MAC:        primaryMAC,
+				InfoSource: netvmispec.InfoSourceDomain,
+				QueueCount: netsetup.DefaultInterfaceQueueCount,
+				LinkState:  linkStateUp,
+			},
+			{Name: sriovNet1, InfoSource: netvmispec.InfoSourceDomain},
+			{Name: sriovNet2, InfoSource: netvmispec.InfoSourceDomain},
+			{Name: sriovNet3, InfoSource: netvmispec.InfoSourceDomain},
+		}
+
+		// Determinism guard: repeated reconciles must produce identical ordering. With the
+		// old code the SR-IOV statuses follow the domain host-device order (2, 3, 1) and
+		// churn against the virt-controller's spec order; with the fix they are stable.
+		for i := 0; i < 20; i++ {
+			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+			Expect(setup.Vmi.Status.Interfaces).To(Equal(expectedStatus),
+				fmt.Sprintf("iteration %d: SR-IOV ifaces must follow VMI spec order", i))
+		}
+	})
+
 	It("run status and expect 1 attached iface & 1 detached iface to be reported based on multus status and guest-agent data", func() {
 		const (
 			primaryNetworkName = "primary"


### PR DESCRIPTION
Part of ENG-91087

A running VMI's `status.interfaces` is rewritten continuously with the same
interfaces in a different order on each reconcile — status churn where every
write is a content no-op but an ordering diff.

There are two writers of `vmi.Status.Interfaces`:

- **virt-controller** (`pkg/network/controllers/vmi.go`) rebuilds the list in
  **VMI spec order** — primary first, then
  `FilterMultusNonDefaultNetworks(vmi.Spec.Networks)`, then non-spec extras.
- **virt-handler** (`NetStat.UpdateStatus`, `pkg/network/setup/netstat.go`)
  assembles the list from several sources.

The churn comes from two places in virt-handler where its order diverges from
virt-controller's spec order. When the two writers disagree they keep
overwriting each other every reconcile. This branch fixes both.

## Fix 1 — multus-only appends ranged a Go map

`ifacesStatusFromMultus` **ranged a Go map** (`multusStatusNetworksByName`) and
appended in that order. Go randomizes map iteration on every range, so any
interface entering status through the append branch — present in the VMI spec
and in the multus `network-status`, but not yet reported by the
domain / guest-agent — landed in a different position each pass. The churn is
self-perpetuating: `multusStatusNetworksByName` is rebuilt from the previous
`vmi.Status.Interfaces`, so each randomized write feeds the next reconcile.

Changes:

- split `ifacesStatusFromMultus` into two loops: a map range that only mutates
  the `InfoSource` of interfaces already in the status (order-irrelevant), and
  a spec-ordered append loop for multus-only interfaces
- change its signature to take the ordered spec slice
  (`vmi.Spec.Domain.Devices.Interfaces`) instead of the spec-by-name map
- deterministic-ordering test: multus secondaries in non-alphabetical spec
  order, driven through the append branch, asserted stable across reconciles

The split is behavior-preserving: the append branch fired for
`name ∈ multus ∧ name ∈ spec ∧ name ∉ status` and the in-place branch for
`name ∈ multus ∧ name ∈ status` — disjoint sets, so splitting them changes
nothing but the append order.

## Fix 2 — SR-IOV host-device order != spec order

Diagnosing a live VMI with 8 IB SR-IOV interfaces showed the churn continued
after Fix 1. Sampling `status.interfaces` repeatedly revealed it was **not**
random — it alternated between exactly two orderings:

- `1,2,3,4,5,6,7,8` — virt-controller's spec order
- `2,3,4,5,8,1,6,7` — a *fixed* permutation written by virt-handler

The churning interfaces carry `infoSource: "domain, multus-status"`, i.e. they
are sourced by `sriovIfacesStatusFromDomainHostDevices` from
`domain.Spec.Devices.HostDevices` (not the multus append branch of Fix 1). That
function emitted them in **domain host-device order**, which follows PCI-address
pool / libvirt slot assignment and does **not** match VMI spec order. So
virt-handler wrote the fixed permutation while virt-controller wrote spec order,
and the two fought every reconcile.

This corrects an assumption in the original plan — that "virt-handler's
domain-sourced interfaces already follow spec order because the domain is built
from spec sequentially." That holds for regular `<interface>` devices but not
for SR-IOV `<hostdev>` devices.

Changes:

- sort `sriovIfacesStatusFromDomainHostDevices` output by VMI spec order (host
  devices with no matching spec interface sort last, keeping relative order)
- change its signature to take the spec slice instead of the spec-by-name map
- deterministic-ordering test: SR-IOV host devices supplied in an order
  different from spec, asserted to come out in spec order across reconciles

## Notes

- The "primary interface first" invariant is unaffected:
  `movePrimaryIfaceStatusToFront` runs before the multus appends (which go to
  the tail), and the primary is a pod-network `<interface>`, never an SR-IOV
  host device.
- Only the `virt-handler` binary is affected; both changed functions are
  reachable solely through `NetStat.UpdateStatus`.
- Known remaining gap (not exercised by the live case): if a VMI interleaves
  bridge-multus and SR-IOV secondaries, virt-handler emits them as two
  spec-ordered groups (regular `<interface>` then `<hostdev>`) rather than a
  single spec-interleaved list, so a residual cross-writer diff is still
  possible. Closing that would require a final spec-order normalization over the
  whole secondary section.
